### PR TITLE
Fixed Connection to MySQL Server with non default port

### DIFF
--- a/lib/metahandler/lib/modules/db_utils.py
+++ b/lib/metahandler/lib/modules/db_utils.py
@@ -45,11 +45,11 @@ class DB_Connection():
                     return None
             db_address = kodi.get_setting('db_address')
             db_port = kodi.get_setting('db_port')
-            if db_port: db_address = '%s:%s' %(db_address,db_port)
+            if not db_port: db_port = '3306'
             db_user = kodi.get_setting('db_user')
             db_pass = kodi.get_setting('db_pass')
             db_name = kodi.get_setting('db_name')
-            self.dbcon = self.database.connect(database=db_name, user=db_user, password=db_pass, host=db_address, buffered=True)
+            self.dbcon = self.database.connect(database=db_name, user=db_user, password=db_pass, host=db_address, port=db_port, buffered=True)
             self.dbcur = self.dbcon.cursor(cursor_class=MySQLCursorDict, buffered=True)
         else:
             self.dbcon = self.database.connect(videocache)

--- a/lib/metahandler/metacontainers.py
+++ b/lib/metahandler/metacontainers.py
@@ -126,12 +126,12 @@ class MetaContainer:
 
             db_address = common.addon.get_setting('db_address')
             db_port = common.addon.get_setting('db_port')
-            if db_port: db_address = '%s:%s' %(db_address,db_port)
+            if not db_port: db_port = '3306'
             db_user = common.addon.get_setting('db_user')
             db_pass = common.addon.get_setting('db_pass')
             db_name = common.addon.get_setting('db_name')
 
-            db = database.connect(db_name, db_user, db_pass, db_address, buffered=True)
+            db = database.connect(db_name, db_user, db_pass, db_address, port=db_port, buffered=True)
             mysql_cur = db.cursor()
             work_db = sqlite.connect(self.work_videocache);
             rows = work_db.execute('SELECT * FROM %s' %table).fetchall()


### PR DESCRIPTION
- I had some problems with this module and my non-default-mysql-port
- a connection with parameter host=db_address:db_port doesn't work, host only allows ip or name (https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html). Address+port would result in an error.
- My fix sets port to 3306, if db_port not defined or empty and connects always via port-param